### PR TITLE
Modernize integration for HA 2024.6+ compatibility (v2.6.0)

### DIFF
--- a/custom_components/nea_sg_weather/config_flow.py
+++ b/custom_components/nea_sg_weather/config_flow.py
@@ -6,6 +6,7 @@ import logging
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.const import (
     CONF_NAME,
     CONF_PREFIX,
@@ -16,7 +17,6 @@ from homeassistant.const import (
     CONF_TIMEOUT,
 )
 from homeassistant.core import callback
-from homeassistant.data_entry_flow import FlowResult
 import homeassistant.helpers.config_validation as cv
 
 from .const import (
@@ -45,6 +45,8 @@ def configured_instances(hass):
 
 class NeaWeatherFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Config flow for NEA SG Weather component."""
+
+    VERSION = 1
 
     def __init__(self):
         """Init NeaWeatherFlowHandler."""
@@ -120,7 +122,7 @@ class NeaWeatherFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             errors=self._errors,
         )
 
-    async def async_step_import(self, user_input: dict | None = None) -> FlowResult:
+    async def async_step_import(self, user_input: dict | None = None) -> ConfigFlowResult:
         """Handle configuration by yaml file."""
         return await self.async_step_user(user_input)
 

--- a/custom_components/nea_sg_weather/manifest.json
+++ b/custom_components/nea_sg_weather/manifest.json
@@ -4,5 +4,7 @@
   "config_flow": true,
   "codeowners": ["@kianhean"],
   "iot_class": "cloud_polling",
-  "version": "2.5.4"
+  "version": "2.6.0",
+  "homeassistant": "2024.6.0",
+  "requirements": ["Pillow>=9.0.0"]
 }


### PR DESCRIPTION
- manifest: add homeassistant min version (2024.6.0), Pillow requirement, bump to v2.6.0
- __init__: replace async_timeout with asyncio.timeout, remove unused imports, await async_forward_entry_setups directly, inject HA-managed aiohttp session
- nea: remove unused imports, accept session param in async_init/fetch_data/Wind.async_init, use native forecast attrs (ATTR_FORECAST_NATIVE_TEMP etc.), fix bare except
- weather: remove deprecated async_setup_platform, fix DeviceInfo import, fix device identifiers, remove deprecated forecast property, return Forecast dataclass instances from async_forecast_daily, remove FORECAST_HOURLY (no real hourly data available)
- sensor: fix DeviceInfo import, fix device identifiers across all 5 sensor classes, use native_value for numeric sensors, add state_class/device_class/units for rain (PRECIPITATION/mm), PM2.5 (PM25/µg/m³), UV (MEASUREMENT)
- camera: fix DeviceInfo import, fix device identifiers, remove deprecated synchronous camera_image method, add missing name/device_info to NeaAnimatedRainCamera, improve exception logging
- config_flow: add VERSION = 1, replace FlowResult with ConfigFlowResult

https://claude.ai/code/session_01LLTAtMATaW87btMghLH2eW