### PR TITLE
Increase default timeout from 10 to 60 seconds

### DIFF
--- a/custom_components/nea_sg_weather/const.py
+++ b/custom_components/nea_sg_weather/const.py
@@ -24,7 +24,7 @@ DOMAIN = "nea_sg_weather"
 ATTRIBUTION = "Weather data from Singapore's NEA"
 DEFAULT_NAME = "Singapore Weather"
 DEFAULT_SCAN_INTERVAL = 15
-DEFAULT_TIMEOUT = 10
+DEFAULT_TIMEOUT = 60
 HEADERS = {
     "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.45 Safari/537.36",
     "referer": "https://www.nea.gov.sg",


### PR DESCRIPTION
# Fix: Increase `DEFAULT_TIMEOUT` to accommodate sequential API fetches

## Summary

The default timeout of 10 seconds is too tight for the integration's sequential fetch architecture, causing spurious `UpdateFailed` errors and `success: False` on coordinator updates under normal API conditions.

## Initial Error Logs
```
2026-03-24 05:25:33.020 DEBUG (MainThread) [custom_components.nea_sg_weather.nea] Forecast24hr: response received, length: 2095
2026-03-24 05:25:33.020 DEBUG (MainThread) [custom_components.nea_sg_weather.nea] Forecast24hr: Data processed
2026-03-24 05:25:33.144 DEBUG (MainThread) [custom_components.nea_sg_weather.nea] UVIndex: response received, length: 840
2026-03-24 05:25:33.144 DEBUG (MainThread) [custom_components.nea_sg_weather.nea] UVIndex: Data processed
2026-03-24 05:25:33.354 DEBUG (MainThread) [custom_components.nea_sg_weather.nea] Forecast2hr: response received, length: 6733
2026-03-24 05:25:33.354 DEBUG (MainThread) [custom_components.nea_sg_weather.nea] Forecast2hr: Data processed
2026-03-24 05:25:35.539 DEBUG (MainThread) [custom_components.nea_sg_weather.nea] WindDirection: response received, length: 2524
2026-03-24 05:25:35.539 DEBUG (MainThread) [custom_components.nea_sg_weather.nea] WindDirection: Data processed
2026-03-24 05:25:40.036 DEBUG (MainThread) [custom_components.nea_sg_weather.nea] WindSpeed: response received, length: 2536
2026-03-24 05:25:40.036 DEBUG (MainThread) [custom_components.nea_sg_weather.nea] WindSpeed: Data processed
2026-03-24 05:25:41.985 DEBUG (MainThread) [custom_components.nea_sg_weather.nea] Humidity: response received, length: 2532
2026-03-24 05:25:41.985 DEBUG (MainThread) [custom_components.nea_sg_weather.nea] Humidity: Data processed
2026-03-24 05:25:42.904 DEBUG (MainThread) [custom_components.nea_sg_weather] Finished fetching nea_sg_weather data in 10.001 seconds (success: False)
```

I enlisted Claude to help solve this error and the following adjustment to the timeout solved the problem. This may prevent others from encountering this out-of-the-box problem.

## Root Cause

`_async_update_data()` in `__init__.py` wraps all fetches in a single `asyncio.timeout()` context:

```python
async with timeout(self.timeout):
    return await self.weather.async_update()
```

`async_update()` fetches up to 9 API endpoints **sequentially**. With a 10-second budget shared across all requests, each endpoint has less than ~1.1 seconds on average. The data.gov.sg API is a public service subject to variable latency; any transient slowness on a single endpoint consumes the remaining budget for all subsequent fetches, causing a `TimeoutError` that propagates as `UpdateFailed`.

This manifests in the HA log as:

```
Finished fetching nea_sg_weather data in 10.001 seconds (success: False)
```

Note that individual endpoints may log "Data processed" successfully — the timeout fires between fetches, not within a single request.

## Change

**File modified:** `custom_components/nea_sg_weather/const.py`

```python
# Before
DEFAULT_TIMEOUT = 10

# After
DEFAULT_TIMEOUT = 60
```

60 seconds provides a generous margin for 9 sequential requests while still bounding the total update duration well within the default 15-minute polling interval.

Users who have already configured a custom timeout via the UI will not be affected — `DEFAULT_TIMEOUT` is only applied on first setup when no explicit value has been set.

## Notes for maintainers

The timeout constraint would be less of a concern if fetches were made concurrently via `asyncio.gather()`. However, sequential fetching is a reasonable design choice for a public API to avoid request bursts, so increasing the default timeout is the appropriate fix here.